### PR TITLE
calcite에서 제공한 rule과 relation을 사용한 couchdb adpater code

### DIFF
--- a/calcite-main/.idea/vcs.xml
+++ b/calcite-main/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/calcite-main/build.gradle.kts
+++ b/calcite-main/build.gradle.kts
@@ -213,7 +213,7 @@ val javadocAggregateIncludingTests by tasks.registering(Javadoc::class) {
 }
 
 val adaptersForSqlline = listOf(
-    ":arrow", ":babel", ":cassandra",":couchdb", ":druid", ":elasticsearch",
+    ":arrow", ":babel", ":cassandra",":couchdb", ":couchdbOriginLink", ":druid", ":elasticsearch",
     ":file", ":geode", ":innodb", ":kafka", ":mongodb",
     ":pig", ":piglet", ":plus", ":redis", ":spark", ":splunk")
 

--- a/calcite-main/couchdbOriginLink/build.gradle.kts
+++ b/calcite-main/couchdbOriginLink/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+dependencies {
+    api(project(":core"))
+    api(project(":linq4j"))
+    api("com.google.guava:guava")
+    api("org.slf4j:slf4j-api")
+
+    implementation("org.apache.calcite.avatica:avatica-core")
+    // https://mvnrepository.com/artifact/org.lightcouch/lightcouch
+    implementation("org.lightcouch:lightcouch:0.2.0")
+    // https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple
+    implementation("com.googlecode.json-simple:json-simple:1.1.1")
+
+    testImplementation(project(":testkit"))
+    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl")
+}
+

--- a/calcite-main/couchdbOriginLink/gradle.properties
+++ b/calcite-main/couchdbOriginLink/gradle.properties
@@ -1,0 +1,2 @@
+description=CouchDB adapter for Calcite using calcite origin adapter
+artifact.name=Calcite CouchDB

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchEnumerator.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchEnumerator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.couchdbOriginLink;
+
+import org.apache.calcite.linq4j.Enumerator;
+
+import java.util.List;
+
+public class CouchEnumerator implements Enumerator<Object[]> {
+  private final List<Object> rows;
+  private Object[] current;
+
+  public CouchEnumerator(List<Object> rows) {
+    this.rows = rows;
+  }
+
+  @Override
+  public Object[] current() {
+    return current;
+  }
+
+  @Override
+  public boolean moveNext() {
+    current = null;
+
+    if (!rows.isEmpty()) {
+      current = rows.toArray();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public void reset() {
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchEnumerator.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchEnumerator.java
@@ -24,6 +24,7 @@ import java.util.List;
 public class CouchEnumerator implements Enumerator<Object[]> {
   private final List<Object> rows;
   private Object[] current;
+  private int index = 0;
 
   public CouchEnumerator(List<Object> rows) {
     this.rows = rows;
@@ -37,13 +38,16 @@ public class CouchEnumerator implements Enumerator<Object[]> {
   @Override
   public boolean moveNext() {
     current = null;
+    Object[] o = new Object[1];
 
-    if (!rows.isEmpty()) {
-      current = rows.toArray();
-      return true;
+    if(index < rows.size()) {
+      o[0] = rows.get(index);
+      current = o;
+      index++;
     } else {
       return false;
     }
+    return true;
   }
 
   @Override

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchSchema.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchSchema.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.couchdbOriginLink;
+
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.lightcouch.CouchDbClient;
+import org.lightcouch.CouchDbProperties;
+
+import java.io.IOException;
+import java.util.Map;
+
+
+public class CouchSchema extends AbstractSchema {
+  protected final CouchDbClient dbClient;
+  protected CouchDbProperties properties;
+  protected final Map<String, Object> infoMap;
+  protected final JSONParser jsonParser;
+
+  public CouchSchema(Map<String, Object> infoMap, int port) {
+    super();
+    this.infoMap = infoMap;
+    this.jsonParser = new JSONParser();
+
+    this.properties = new CouchDbProperties();
+    this.properties.setConnectionTimeout(0);
+    this.properties.setProtocol((String) infoMap.get("protocol"));
+    this.properties.setUsername((String) infoMap.get("username"));
+    this.properties.setPassword((String) infoMap.get("password"));
+    this.properties.setPort(port);
+    this.properties.setHost((String) infoMap.get("host"));
+    this.properties.setDbName((String) infoMap.get("database"));
+
+    this.dbClient = new CouchDbClient(properties);
+  }
+
+  // couchDB API를 통해 document 목록을 불러와서 테이블을 생성
+  @Override
+  protected Map<String, Table> getTableMap() {
+    final ImmutableMap.Builder<String, Table> builder = ImmutableMap.builder();
+
+    // Database에 위치한 docs들 정보를 가져옴
+    HttpGet uri = new HttpGet(dbClient.getDBUri()+"/_all_docs");
+    CloseableHttpResponse response = (CloseableHttpResponse) dbClient.executeRequest(uri);
+
+    try {
+      String json = EntityUtils.toString(response.getEntity(), "UTF-8");
+      JSONArray rows = (JSONArray)((JSONObject) jsonParser.parse(json)).get("rows");
+
+      for (int i = 0; i < rows.size(); i++) {
+        JSONObject parse = (JSONObject) rows.get(i);
+        String documentId = (String) parse.get("id");
+
+        builder.put(documentId, new CouchTable(this, null, jsonParser, documentId));
+      }
+    } catch (IOException | ParseException e) {
+        throw new RuntimeException(e);
+    }
+
+    return builder.build();
+  }
+
+  public CouchDbClient getDbClient() {
+    return dbClient;
+  }
+}

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchSchemaFactory.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchSchemaFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.couchdbOriginLink;
+
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaFactory;
+import org.apache.calcite.schema.SchemaPlus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CouchSchemaFactory implements SchemaFactory {
+  public CouchSchemaFactory() {
+    super();
+  }
+
+  private static final int DEFAULT_COUCHDB_PORT = 5984;
+
+  @Override
+  public Schema create(SchemaPlus parentSchema, String name, Map<String, Object> operand) {
+    Map<String, Object> info_map = getInfo(operand);
+    return new CouchSchema(info_map, getPort(operand));
+  }
+
+  private Map<String, Object> getInfo(Map<String, Object> map) {
+    Map<String, Object> ret = new HashMap<>();
+
+    final String host = (String) map.get("host");
+    final String username = (String) map.get("username");
+    final String password = (String) map.get("password");
+    final String protocol = (String) map.get("protocol");
+    final String database = (String) map.get("database");
+
+    ret.put("host", host);
+    ret.put("username", username);
+    ret.put("password", password);
+    ret.put("protocol", protocol);
+    ret.put("database", database);
+    return ret;
+  }
+
+  private int getPort(Map<String, Object> map) {
+    if (map.containsKey("port")) {
+      Object port = map.get("port");
+      if(port instanceof String)
+        return Integer.parseInt((String) map.get("port"));
+      return (int) port;
+    }
+
+    return DEFAULT_COUCHDB_PORT;
+  }
+}

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTable.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTable.java
@@ -91,13 +91,12 @@ public class CouchTable extends AbstractTable implements ScannableTable {
       String res = EntityUtils.toString(entity, "UTF-8");
       JSONObject rows = (JSONObject) jsonParser.parse(res);
 
-      int row = 0;
       Map<String, String> map = new ObjectMapper().readValue(rows.toJSONString(), Map.class);
 
 
       try {
-        values = Arrays.asList(map.entrySet().toArray());
-        for (Object o : values) {
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+          Object o = entry;
           list.add(o);
         }
         System.out.println(list);

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTable.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTable.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.couchdbOriginLink;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.linq4j.AbstractEnumerable;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class CouchTable extends AbstractTable implements ScannableTable {
+  private final List<Object> list = new ArrayList<>();
+  private final CouchSchema schema;
+  private final RelProtoDataType protoRowType;
+  private final JSONParser jsonParser;
+  private final String documentId;
+  CouchEnumerator couchEnumerator;
+
+  public CouchTable(CouchSchema schema, RelProtoDataType protoRowType, JSONParser jsonParser,
+      String documentId) {
+    this.schema = schema;
+    this.protoRowType = protoRowType;
+    this.jsonParser = jsonParser;
+    this.documentId = documentId;
+  }
+
+  static Table create(CouchSchema schema, String tableName, RelProtoDataType protoRowType) {
+    return new CouchTable(schema, protoRowType, new JSONParser(), tableName);
+  }
+
+  @Override
+  public String toString() {
+    return "CouchTable {" + documentId + '}';
+  }
+
+  // table의 attribute 설정
+  // MAP이라는 attirbute 하나만 생성해서 때려박음
+  @Override
+  public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+    final RelDataType mapType = typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true));
+
+    return typeFactory.builder().add(documentId, mapType).build();
+  }
+
+  // table(document)내의 row를 가져옴
+  private void find() {
+    String tableUri = schema.getDbClient().getDBUri() + "/" + documentId;
+
+    // document 불러오는 코드
+    HttpGet docs = new HttpGet(tableUri);
+    HttpEntity entity = schema.getDbClient().executeRequest(docs).getEntity();
+    List<Object> list = new ArrayList<>();
+
+    try {
+      String res = EntityUtils.toString(entity, "UTF-8");
+      JSONObject rows = (JSONObject) jsonParser.parse(res);
+
+      int row = 0;
+      Map<String, String> map = new ObjectMapper().readValue(rows.toJSONString(), Map.class);
+
+
+      try {
+        list = Arrays.asList(map.values().toArray());
+        } catch (Exception e) {
+        throw new RuntimeException();
+      }
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Enumerable<@Nullable Object[]> scan(DataContext root) {
+
+    find();
+    return new AbstractEnumerable<Object[]>() {
+      @Override
+      public Enumerator<Object[]> enumerator() {
+        return new CouchEnumerator(list);
+      }
+    };
+  }
+
+
+}

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTable.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTable.java
@@ -85,7 +85,7 @@ public class CouchTable extends AbstractTable implements ScannableTable {
     // document 불러오는 코드
     HttpGet docs = new HttpGet(tableUri);
     HttpEntity entity = schema.getDbClient().executeRequest(docs).getEntity();
-    List<Object> list = new ArrayList<>();
+    List<Object> values = new ArrayList<>();
 
     try {
       String res = EntityUtils.toString(entity, "UTF-8");
@@ -96,7 +96,11 @@ public class CouchTable extends AbstractTable implements ScannableTable {
 
 
       try {
-        list = Arrays.asList(map.values().toArray());
+        values = Arrays.asList(map.entrySet().toArray());
+        for (Object o : values) {
+          list.add(o);
+        }
+        System.out.println(list);
         } catch (Exception e) {
         throw new RuntimeException();
       }

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTableScan.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchTableScan.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.couchdbOriginLink;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.core.TableScan;
+
+import com.google.common.collect.ImmutableList;
+
+public class CouchTableScan extends TableScan {
+
+  protected CouchTableScan(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table) {
+      super(cluster, traitSet, ImmutableList.of(), table);
+  }
+}

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchToEnumerableConverter.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/CouchToEnumerableConverter.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.couchdbOriginLink;
+
+public class CouchToEnumerableConverter {
+}

--- a/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/package-info.java
+++ b/calcite-main/couchdbOriginLink/src/main/java/org/apache/calcite/adapter/couchdbOriginLink/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.adapter.couchdbOriginLink;

--- a/calcite-main/couchdbOriginLink/src/test/java/test1.java
+++ b/calcite-main/couchdbOriginLink/src/test/java/test1.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+public class test1 {
+
+
+}

--- a/calcite-main/couchdbOriginLink/src/test/resources/test1.json
+++ b/calcite-main/couchdbOriginLink/src/test/resources/test1.json
@@ -1,0 +1,20 @@
+
+{
+  "version": "1.0",
+  "defaultSchema": "couch_test1",
+  "schemas": [
+    {
+      "type": "custom",
+      "name": "couch_test1",
+      "factory": "org.apache.calcite.adapter.couchdb.CouchDBSchemaFactory",
+      "operand": {
+        "host": "localhost",
+        "username": "adming",
+        "password": "my0504",
+        "db.name": "wiki",
+        "protocol": "http",
+        "port": "5984"
+      }
+    }
+  ]
+}

--- a/calcite-main/model-couch-foundation.json
+++ b/calcite-main/model-couch-foundation.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0",
+  "defaultSchema": "COUCH",
+  "schemas": [
+    {
+      "type": "custom",
+      "name" : "test",
+      "factory": "org.apache.calcite.adapter.couchdbOriginLink.CouchSchemaFactory",
+      "operand": {
+        "host": "localhost",
+        "username": "admin",
+        "password": "password",
+        "protocol": "http",
+        "port": "5984",
+        "database": "wiki"
+      }
+    }
+  ]
+}

--- a/calcite-main/settings.gradle.kts
+++ b/calcite-main/settings.gradle.kts
@@ -71,6 +71,7 @@ include(
     "cassandra",
     "core",
     "couchdb",
+    "couchdbOriginLink",
     "druid",
     "elasticsearch",
     "example:csv",


### PR DESCRIPTION
#1 
- calcite에서 지원하는 class와 interface를 사용해서 couch adapter 구현
- 직접 rule과 relation을 구현하는 코드와 분리를 목적으로 새로운 `couchdbOriginLink`라는 모듈 생성
- gradle build 파일과 setting 파일에 couchdbOriginLink 추가
- 연결 json 파일 - `model-couch-foundation.json`

---
### 0. document for test
```json
{
  "0": {
    "_id": "list0",
    "row1": "list0test"
  },
  "1": {
    "_id": "list1",
    "row1": "list1test"
  },
  "_id": "wiki",
  "_rev": "3-9cb75bd62d76c2a6f74f2b0d905f5f6a",
  "row1": "hello",
  "row2": "nice meet you",
  "row3": "!"
}
```

### 1. sql 연결
```bash
$ ./sqlline
sqlline> !connect jdbc:calcite:model=model-couch-foundation.json admin admin
```

### 2, db 연결 확인
``` bash
0: jdbc:calcite:model=model-couch-foundation.> !table
+-----------+-------------+----------------------------------+--------------+---------+----------+------------+-----------+---------------------------+----------------+
| TABLE_CAT | TABLE_SCHEM |            TABLE_NAME            |  TABLE_TYPE  | REMARKS | TYPE_CAT | TYPE_SCHEM | TYPE_NAME | SELF_REFERENCING_COL_NAME | REF_GENERATION | 
+-----------+-------------+----------------------------------+--------------+---------+----------+------------+-----------+---------------------------+----------------+ 
...
|           | test        | d2f9c37ef5e1af2dca48304fcb005f20 | TABLE        |         |          |            |           |                           |                | 
|           | test        | d2f9c37ef5e1af2dca48304fcb007da4 | TABLE        |         |          |            |           |                           |                | 
|           | test        | wiki                             | TABLE        |         |          |            |           |                           |                | 
...
+-----------+-------------+----------------------------------+--------------+---------+----------+------------+-----------+---------------------------+----------------+ 
```

### 3. select 사용
```bash
0: jdbc:calcite:model=model-couch-foundation.> select * from "test"."wiki";
+-----------------------------------------+
|                  wiki                   |
+-----------------------------------------+
| 0={row1=list0test, _id=list0}           |
| 1={row1=list1test, _id=list1}           |
| row1=hello                              |
| _rev=3-9cb75bd62d76c2a6f74f2b0d905f5f6a |
| _id=wiki                                |
| row3=!                                  |
| row2=nice meet you                      |
+-----------------------------------------+
7 rows selected (1.407 seconds)
```

### 4. where 사용
```bash
0: jdbc:calcite:model=model-couch-foundation.> select * from "test"."wiki" where "wiki" like '%id%';
Error: Error while executing SQL "select * from "test"."wiki" where "wiki" like '%id%'": From line 1, column 35 to line 1, column 52: Cannot apply 'LIKE' to arguments of type 'LIKE(<(VARCHAR, ANY) MAP>, <CHAR(4)>)'. Supported form(s): 'LIKE(<STRING>, <STRING>, <STRING>)' (state=,code=0)
```
> Error: Error while executing SQL "select * from "test"."wiki" where "wiki" like '%id%'": From line 1, column 35 to line 1, column 52: Cannot apply 'LIKE' to arguments of type 'LIKE(<(VARCHAR, ANY) MAP>, <CHAR(4)>)'. Supported form(s): 'LIKE(<STRING>, <STRING>, <STRING>)' (state=,code=0)

-> type이 안 맞아서 생기는 오류
- [ ] type modification 